### PR TITLE
Feature/cosmetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *__pycache__
+dev*

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from labylib.labylib import Cape

--- a/labylib/Cape.py
+++ b/labylib/Cape.py
@@ -2,15 +2,11 @@ import requests
 import hashlib
 import time
 
-class RequestError(Exception): pass
-
 class Texture:
 
 	endpoint = "https://www.labymod.net/page/php/cape.php"
 
-	def __init__(self,cookie,img):
-		self.validate(cookie,img)
-
+	def __init__(self,cookie):
 		self.body = b"" # Initialize request body
 		self.cookies = dict(PHPSESSID = cookie)
 		self.boundary = self.boundary()
@@ -33,12 +29,8 @@ class Texture:
 		}
 		
 		self.appendBinaryFormData(b"cosmetic",b"cape")
-		self.appendBinaryFormData(b"file",self.bOpen(img))
 
 	# -----------------------------------
-
-	def validate(self,cookie,file):
-		return True
 
 	# Generate boundary header from MD5-hash of current time
 	def boundary(self):
@@ -83,7 +75,9 @@ class Texture:
 
 	# -----------------------------------
 
-	def update(self):
+	def update(self,img):
+		self.appendBinaryFormData(b"file",self.bOpen(img))
+
 		self.closeBinaryFormData() # Add final boundary header
 
 		request = requests.post(Texture.endpoint,
@@ -93,17 +87,98 @@ class Texture:
 		)
 
 		# Raise exception if request fails
-		# Use [3:5] to clean up junk chars from reponse body
-		if(str(request.text)[3:5] != "OK"):
-			raise RequestError(str(request.text))
+		request.raise_for_status()
+
+class Template:
+
+	endpoint = "https://www.labymod.net/page/php/setCapeTpl.php"
+	templates = {
+		"labymod": "10_LABYMOD.png",
+		"minecon2011": "30_MINECON2011.png",
+		"minecon2012": "30_MINECON2012.png",
+		"minecon2013": "30_MINECON2013.png",
+		"minecon2015": "30_MINECON2015.png",
+		"minecon2016": "30_MINECON2016.png",
+		"minecon2019": "30_MINECON2019.png",
+		"prismarine": "30_PRISMARINE.png",
+		"christmas2010": "40_CHRISTMAS2010.png",
+		"cobalt": "40_COBALT.png",
+		"julianclark": "40_JULIANCLARK.png",
+		"mapmaker": "40_MAPMAKER.png",
+		"mojira": "40_MOJIRA.png",
+		"mrmessiah": "40_MRMESSIAH.png",
+		"newyear": "40_NEWYEAR.png",
+		"scrolls": "40_SCROLLS.png",
+		"translator": "40_TRANSLATOR.png",
+		"turtle": "40_TURTLE.png",
+		"winner": "40_WINNER.png"
+	}
+
+	def __init__(self,cookie):
+		self.cookies = dict(PHPSESSID = cookie)
+
+		self.headers = {
+			"accept": "*/*",
+			"accept-encoding": "gzip, deflate, br",
+			"accept-language": "en-US,en;q=0.9,sv;q=0.8",
+			"cache-control": "no-cache",
+			"dnt": "1",
+			"user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:33.0) Gecko/20100101 Firefox/33.0",
+			"origin": "https://www.labymod.net",
+			"pragma": "no-cache",
+			"referer": "https://www.labymod.net/dashboard",
+			"sec-fetch-dest": "empty",
+			"sec-fetch-mode": "cors",
+			"sec-fetch-site": "same-origin",
+			"x-requested-with": "XMLHttpRequest",
+			"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+		}
+
+		self.body = ""
+
+		# Payload
+		self.addEncodedFormData("cosmetic","cape")
+
+	# -----------------------------------
+
+	# Add URLEncoded form data (x-www-form-urlencoded)
+	def addEncodedFormData(self,key,value):
+		body = "&"
+
+		# Remove '&' delimiter for first item
+		if(self.body == ""):
+			body = ""
+
+		body += f"{key}={value}"
+
+		self.body += body
+
+	# -----------------------------------
+
+	def update(self,value):
+		value = value.lower()
+
+		if(value not in Template.templates):
+			raise ValueError(f"'{value}' is not a valid template.")
+
+		texture = Template.templates[value]
+
+		self.addEncodedFormData("cape",texture)
+
+		request = requests.post(Template.endpoint,
+			headers = self.headers,
+			cookies = self.cookies,
+			data = self.body
+		)
+
+		# Raise exception if request fails
+		request.raise_for_status()
 
 class Visibility:
 
 	endpoint = "https://www.labymod.net/api/change"
 
-	def __init__(self,cookie,value):
-		self.validate(cookie,value)
-
+	def __init__(self,cookie):
 		self.cookies = dict(PHPSESSID = cookie)
 
 		self.headers = {
@@ -127,14 +202,10 @@ class Visibility:
 
 		# Payload
 		self.addEncodedFormData("type","switch")
-		self.addEncodedFormData("value",value)
 		self.addEncodedFormData("item",459595)
 		self.addEncodedFormData("site","control")
 
 	# -----------------------------------
-
-	def validate(self,cookie,file):
-		return True
 
 	# Add URLEncoded form data (x-www-form-urlencoded)
 	def addEncodedFormData(self,key,value):
@@ -150,14 +221,23 @@ class Visibility:
 
 	# -----------------------------------
 
-	def update(self):
-		request = requests.post(Texture.endpoint,
+	def update(self,value):
+		# Interpret strings 
+		if(type(value) != int):
+			if(value == "show"):
+				value = 1
+			elif(value == "hide"):
+				value = 0
+			else:
+				raise ValueError(f"'{value}' is not a valid visibility state.")
+
+		self.addEncodedFormData("value",value)
+
+		request = requests.post(Visibility.endpoint,
 			headers = self.headers,
 			cookies = self.cookies,
 			data = self.body
 		)
 
 		# Raise exception if request fails
-		# Use [3:5] to clean up junk chars from reponse body
-		if(str(request.text)[3:5] != "OK"):
-			raise RequestError(str(request.text))
+		request.raise_for_status()

--- a/labylib/Cape.py
+++ b/labylib/Cape.py
@@ -96,3 +96,68 @@ class Texture:
 		# Use [3:5] to clean up junk chars from reponse body
 		if(str(request.text)[3:5] != "OK"):
 			raise RequestError(str(request.text))
+
+class Visibility:
+
+	endpoint = "https://www.labymod.net/api/change"
+
+	def __init__(self,cookie,value):
+		self.validate(cookie,value)
+
+		self.cookies = dict(PHPSESSID = cookie)
+
+		self.headers = {
+			"accept": "*/*",
+			"accept-encoding": "gzip, deflate, br",
+			"accept-language": "en-US,en;q=0.9,sv;q=0.8",
+			"cache-control": "no-cache",
+			"dnt": "1",
+			"user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:33.0) Gecko/20100101 Firefox/33.0",
+			"origin": "https://www.labymod.net",
+			"pragma": "no-cache",
+			"referer": "https://www.labymod.net/dashboard",
+			"sec-fetch-dest": "empty",
+			"sec-fetch-mode": "cors",
+			"sec-fetch-site": "same-origin",
+			"x-requested-with": "XMLHttpRequest",
+			"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+		}
+
+		self.body = ""
+
+		# Payload
+		self.addEncodedFormData("type","switch")
+		self.addEncodedFormData("value",value)
+		self.addEncodedFormData("item",459595)
+		self.addEncodedFormData("site","control")
+
+	# -----------------------------------
+
+	def validate(self,cookie,file):
+		return True
+
+	# Add URLEncoded form data (x-www-form-urlencoded)
+	def addEncodedFormData(self,key,value):
+		body = "&"
+
+		# Remove '&' delimiter for first item
+		if(self.body == ""):
+			body = ""
+
+		body += f"{key}={value}"
+
+		self.body += body
+
+	# -----------------------------------
+
+	def update(self):
+		request = requests.post(Texture.endpoint,
+			headers = self.headers,
+			cookies = self.cookies,
+			data = self.body
+		)
+
+		# Raise exception if request fails
+		# Use [3:5] to clean up junk chars from reponse body
+		if(str(request.text)[3:5] != "OK"):
+			raise RequestError(str(request.text))

--- a/labylib/Hat.py
+++ b/labylib/Hat.py
@@ -1,0 +1,126 @@
+import requests
+
+class Texture:
+
+	endpoint = "https://www.labymod.net/api/change"
+
+	def __init__(self,cookie):
+		self.cookies = dict(PHPSESSID = cookie)
+
+		self.headers = {
+			"accept": "*/*",
+			"accept-encoding": "gzip, deflate, br",
+			"accept-language": "en-US,en;q=0.9,sv;q=0.8",
+			"cache-control": "no-cache",
+			"dnt": "1",
+			"user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:33.0) Gecko/20100101 Firefox/33.0",
+			"origin": "https://www.labymod.net",
+			"pragma": "no-cache",
+			"referer": "https://www.labymod.net/dashboard",
+			"sec-fetch-dest": "empty",
+			"sec-fetch-mode": "cors",
+			"sec-fetch-site": "same-origin",
+			"x-requested-with": "XMLHttpRequest",
+			"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+		}
+
+		self.body = ""
+
+		# Payload
+		self.addEncodedFormData("type","country")
+		self.addEncodedFormData("item",459594)
+		self.addEncodedFormData("site","control")
+
+	# -----------------------------------
+
+	# Add URLEncoded form data (x-www-form-urlencoded)
+	def addEncodedFormData(self,key,value):
+		body = "&"
+
+		# Remove '&' delimiter for first item
+		if(self.body == ""):
+			body = ""
+
+		body += f"{key}={value}"
+
+		self.body += body
+
+	# -----------------------------------
+
+	def update(self,value):
+		self.addEncodedFormData("value",value)
+
+		request = requests.post(Texture.endpoint,
+			headers = self.headers,
+			cookies = self.cookies,
+			data = self.body
+		)
+
+		# Raise exception if request fails
+		request.raise_for_status()
+
+class Visibility:
+
+	endpoint = "https://www.labymod.net/api/change"
+
+	def __init__(self,cookie):
+		self.cookies = dict(PHPSESSID = cookie)
+
+		self.headers = {
+			"accept": "*/*",
+			"accept-encoding": "gzip, deflate, br",
+			"accept-language": "en-US,en;q=0.9,sv;q=0.8",
+			"cache-control": "no-cache",
+			"dnt": "1",
+			"user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:33.0) Gecko/20100101 Firefox/33.0",
+			"origin": "https://www.labymod.net",
+			"pragma": "no-cache",
+			"referer": "https://www.labymod.net/dashboard",
+			"sec-fetch-dest": "empty",
+			"sec-fetch-mode": "cors",
+			"sec-fetch-site": "same-origin",
+			"x-requested-with": "XMLHttpRequest",
+			"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+		}
+
+		self.body = ""
+
+		# Payload
+		self.addEncodedFormData("type","switch")
+		self.addEncodedFormData("item",459594)
+		self.addEncodedFormData("site","control")
+
+	# -----------------------------------
+
+	# Add URLEncoded form data (x-www-form-urlencoded)
+	def addEncodedFormData(self,key,value):
+		body = "&"
+
+		# Remove '&' delimiter for first item
+		if(self.body == ""):
+			body = ""
+
+		body += f"{key}={value}"
+
+		self.body += body
+
+	# -----------------------------------
+
+	def update(self,value):
+		# Interpret strings 
+		if(type(value) != int):
+			if(value == "show"):
+				value = 1
+			else:
+				value = 0
+
+		self.addEncodedFormData("value",value)
+
+		request = requests.post(Visibility.endpoint,
+			headers = self.headers,
+			cookies = self.cookies,
+			data = self.body
+		)
+
+		# Raise exception if request fails
+		request.raise_for_status()


### PR DESCRIPTION
Closes issue #2 as `validate()` won't even be performed on a __init__ level anymore; cosmetic values are set from `update()` as of this commit. That means `PHPSESSID` and cosmetic values will get separated.

* 18b6ef

All customizable elements of 'Hat' and 'Cape' are now implemented.

Values are now submitted directly from the 'update()' which means you can easily chain actions without having to create a new instance.

Removed 'validate()' for now.

Removed '__init__.py' from repo root as labylib should be installed as a Python package.